### PR TITLE
Replace Slack with Discord and update X badge in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WSO2 API Manager Documentation
 
-[![slack](https://img.shields.io/badge/slack-wso2--apim-blueviolet)](https://join.slack.com/t/wso2-apim/shared_invite/enQtNzEzMzk5Njc5MzM0LTgwODI3NmQ1MjI0ZDQyMGNmZGI4ZjdkZmI1ZWZmMjNkY2E0NmY3ZmExYjkxYThjNzNkOTU2NWJmYzM4YzZiOWU?)
+[![discord](https://img.shields.io/badge/discord-wso2-blueviolet)](https://discord.com/invite/wso2)
+[![X](https://img.shields.io/badge/X-wso2apimanager-1DA1F2?logo=twitter&logoColor=white)](https://x.com/wso2apimanager?lang=en)
 [![StackOverflow](https://img.shields.io/badge/stackoverflow-wso2am-orange)](https://stackoverflow.com/tags/wso2-am/)
 [![Jenkins Build](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fview%2Fdocs%2Fjob%2Fdocs%2Fjob%2Fdocs-apim%2F)](https://wso2.org/jenkins/view/docs/job/docs/job/docs-apim)
 


### PR DESCRIPTION
## Purpose
> The project has migrated from Slack to Discord for community communication. The README currently references Slack, which is no longer used. This PR resolves issue #9639 by updating the links and badges to reflect Discord and X (formerly Twitter).

## Goals
> Update the README to replace the Slack badge/link with a Discord badge/link and ensure the X profile is correctly referenced. This keeps community links accurate and up to date.

## Approach
> - Removed the Slack badge and link.
> - Added a Discord badge linking to: https://discord.com/invite/wso2
> - Added/verified the X badge linking to: https://x.com/wso2apimanager?lang=en
> - Used Shields.io for consistent badge styling.

## User stories
> As a community member, I want to see accurate links in the README so I can join the correct communication channels.

## Release note
> README.md updated to replace Slack with Discord and added an X profile badge.

## Documentation
> N/A — This is only a README update; no product documentation affected.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? (Yes)
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Tested visually on GitHub README preview.

## Learning
> Shields.io used for badges, Discord and X community guidelines reviewed for proper linking.
